### PR TITLE
added ingest, loader, data dictionary

### DIFF
--- a/src/data_agent/cli.py
+++ b/src/data_agent/cli.py
@@ -1,215 +1,184 @@
 """CLI interface for the data agent using Typer."""
 
-import typer
 from typing import Optional
+
+import typer
+
 from data_agent import config
-from data_agent.utils.logging import setup_logging, get_logger
+from data_agent.utils.logging import get_logger, setup_logging
 
 app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
-    help="SynMax Data Agent - Natural language queries over gas pipeline data"
+    help="SynMax Data Agent - Natural language queries over gas pipeline data",
 )
 
 # Set up logging on module import
 setup_logging()
 logger = get_logger("cli")
 
+
 @app.command()
 def load(
-    path: Optional[str] = typer.Option(
-        None, 
-        "--path", 
-        help="Path to parquet file to load"
-    ),
+    path: Optional[str] = typer.Option(None, "--path", help="Path to parquet file to load"),
     auto: bool = typer.Option(
-        False, 
-        "--auto", 
-        help="Auto-download dataset to ./data/ if path not provided"
-    )
+        False, "--auto", help="Auto-download dataset to ./data/ if path not provided"
+    ),
 ) -> None:
     """Load dataset from --path or auto-download to ./data."""
+    from data_agent.ingest.dictionary import build_data_dictionary, write_dictionary
+    from data_agent.ingest.loader import load_dataset
+
     # Ensure directories exist
     config.ensure_directories()
-    
-    if path:
-        typer.echo(f"Loading dataset from: {path}")
-    elif auto:
-        typer.echo("Auto-downloading dataset to ./data/")
-        # TODO: call ingest.loader.load_dataset(path=None, auto=True)
-    else:
-        typer.echo("Please provide --path to a parquet file or use --auto to download")
-        raise typer.Exit(1)
-    
-    logger.info("Dataset load command executed", extra={"path": path, "auto": auto})
-    typer.echo("Loaded dataset (placeholder).")
+
+    try:
+        # Load the dataset
+        lf = load_dataset(path, auto)
+
+        # Build and write data dictionary
+        data_dict = build_data_dictionary(lf)
+        write_dictionary(data_dict)
+
+        # Print schema information
+        typer.echo(f"Loaded dataset from: {path or 'data/data.parquet'}")
+        typer.echo(f"Rows: {data_dict['n_rows']:,}")
+        typer.echo(f"Columns: {len(data_dict['schema'])}")
+        typer.echo("\nSchema:")
+        for col, dtype in data_dict["schema"].items():
+            null_rate = data_dict["null_rates"][col]
+            typer.echo(f"  {col}: {dtype} (null rate: {null_rate:.1%})")
+
+        typer.echo("\nData dictionary written to: artifacts/data_dictionary.json")
+
+        logger.info(
+            "Dataset load command executed",
+            extra={"path": path, "auto": auto, "rows": data_dict["n_rows"]},
+        )
+
+    except FileNotFoundError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1) from e
+    except Exception as e:
+        typer.echo(f"Unexpected error: {e}", err=True)
+        logger.error("Load command failed", extra={"error": str(e), "path": path, "auto": auto})
+        raise typer.Exit(1) from e
+
 
 @app.command()
 def ask(
     q: str = typer.Argument(..., help="Natural language question about the dataset"),
     planner: str = typer.Option(
-        "deterministic", 
-        "--planner",
-        help="Planner type: deterministic or llm"
+        "deterministic", "--planner", help="Planner type: deterministic or llm"
     ),
-    export: Optional[str] = typer.Option(
-        None,
-        "--export", 
-        help="Export results to JSON file"
-    )
+    export: Optional[str] = typer.Option(None, "--export", help="Export results to JSON file"),
 ) -> None:
     """Ask a natural-language question about the dataset."""
     typer.echo(f"Question: {q}")
     typer.echo(f"Using planner: {planner}")
-    
+
     if export:
         typer.echo(f"Will export results to: {export}")
-    
+
     # TODO: planner.plan(q) -> Plan; executor.run(Plan) -> Answer+Evidence
-    logger.info(
-        "Ask command executed", 
-        extra={"question": q, "planner": planner, "export": export}
-    )
+    logger.info("Ask command executed", extra={"question": q, "planner": planner, "export": export})
     typer.echo("Answer (placeholder)")
+
 
 @app.command()
 def rules(
     pipeline: Optional[str] = typer.Option(
-        None,
-        "--pipeline",
-        help="Filter rules by pipeline name"
+        None, "--pipeline", help="Filter rules by pipeline name"
     ),
-    since: Optional[str] = typer.Option(
-        None,
-        "--since",
-        help="Show rules since date (YYYY-MM-DD)"
-    )
+    since: Optional[str] = typer.Option(None, "--since", help="Show rules since date (YYYY-MM-DD)"),
 ) -> None:
     """Run data quality rules and show violations."""
     typer.echo("Running data quality rules...")
-    
+
     if pipeline:
         typer.echo(f"Filtering by pipeline: {pipeline}")
     if since:
         typer.echo(f"Since date: {since}")
-    
+
     # TODO: rules.engine.run_rules(pipeline=pipeline, since=since)
-    logger.info(
-        "Rules command executed",
-        extra={"pipeline": pipeline, "since": since}
-    )
+    logger.info("Rules command executed", extra={"pipeline": pipeline, "since": since})
     typer.echo("Rules scan (placeholder)")
+
 
 @app.command()
 def metrics(
-    name: str = typer.Option(
-        ...,
-        "--name",
-        help="Metric name: ramp_risk, reversal, or imbalance"
-    ),
-    filters: Optional[str] = typer.Option(
-        None,
-        "--filters",
-        help="Additional filters as JSON"
-    )
+    name: str = typer.Option(..., "--name", help="Metric name: ramp_risk, reversal, or imbalance"),
+    filters: Optional[str] = typer.Option(None, "--filters", help="Additional filters as JSON"),
 ) -> None:
     """Compute analytics metrics."""
     valid_metrics = ["ramp_risk", "reversal", "imbalance"]
     if name not in valid_metrics:
         typer.echo(f"Invalid metric. Choose from: {', '.join(valid_metrics)}")
         raise typer.Exit(1)
-    
+
     typer.echo(f"Computing metric: {name}")
     if filters:
         typer.echo(f"With filters: {filters}")
-    
+
     # TODO: analytics.compute_metric(name, filters)
-    logger.info(
-        "Metrics command executed",
-        extra={"metric_name": name, "filters": filters}
-    )
+    logger.info("Metrics command executed", extra={"metric_name": name, "filters": filters})
     typer.echo(f"Metric {name} (placeholder)")
+
 
 @app.command()
 def events(
     pipeline: Optional[str] = typer.Option(
-        None,
-        "--pipeline",
-        help="Pipeline name to analyze for events"
+        None, "--pipeline", help="Pipeline name to analyze for events"
     ),
     since: Optional[str] = typer.Option(
-        None,
-        "--since",
-        help="Find events since date (YYYY-MM-DD)"
+        None, "--since", help="Find events since date (YYYY-MM-DD)"
     ),
-    top: int = typer.Option(
-        10,
-        "--top",
-        help="Number of top events to show"
-    )
+    top: int = typer.Option(10, "--top", help="Number of top events to show"),
 ) -> None:
     """Detect change-point events in the data."""
     typer.echo("Detecting change-point events...")
-    
+
     if pipeline:
         typer.echo(f"Pipeline: {pipeline}")
     if since:
         typer.echo(f"Since: {since}")
     typer.echo(f"Showing top {top} events")
-    
+
     # TODO: changepoint.detect_events(pipeline, since, top)
-    logger.info(
-        "Events command executed",
-        extra={"pipeline": pipeline, "since": since, "top": top}
-    )
+    logger.info("Events command executed", extra={"pipeline": pipeline, "since": since, "top": top})
     typer.echo("Change-point events (placeholder)")
+
 
 @app.command()
 def cluster(
     entity_type: str = typer.Option(
-        ...,
-        "--entity-type",
-        help="Entity type to cluster: loc or counterparty"
+        ..., "--entity-type", help="Entity type to cluster: loc or counterparty"
     ),
-    k: int = typer.Option(
-        6,
-        "--k",
-        help="Number of clusters"
-    )
+    k: int = typer.Option(6, "--k", help="Number of clusters"),
 ) -> None:
     """Cluster entities by behavior patterns."""
     valid_entity_types = ["loc", "counterparty"]
     if entity_type not in valid_entity_types:
         typer.echo(f"Invalid entity type. Choose from: {', '.join(valid_entity_types)}")
         raise typer.Exit(1)
-    
+
     typer.echo(f"Clustering {entity_type} entities into {k} clusters...")
-    
+
     # TODO: clustering.cluster_entities(entity_type, k)
-    logger.info(
-        "Cluster command executed",
-        extra={"entity_type": entity_type, "k": k}
-    )
+    logger.info("Cluster command executed", extra={"entity_type": entity_type, "k": k})
     typer.echo(f"Clustered {entity_type} entities (placeholder)")
+
 
 @app.command()
 def cache(
-    clear: bool = typer.Option(
-        False,
-        "--clear",
-        help="Clear the cache"
-    ),
-    stats: bool = typer.Option(
-        False,
-        "--stats",
-        help="Show cache statistics"
-    )
+    clear: bool = typer.Option(False, "--clear", help="Clear the cache"),
+    stats: bool = typer.Option(False, "--stats", help="Show cache statistics"),
 ) -> None:
     """Manage query result cache."""
     if clear and stats:
         typer.echo("Cannot use --clear and --stats together")
         raise typer.Exit(1)
-    
+
     if clear:
         # TODO: cache.clear_cache()
         typer.echo("Cache cleared")
@@ -220,6 +189,7 @@ def cache(
         logger.info("Cache stats requested")
     else:
         typer.echo("Use --clear to clear cache or --stats to show statistics")
+
 
 if __name__ == "__main__":
     app()

--- a/src/data_agent/config.py
+++ b/src/data_agent/config.py
@@ -2,7 +2,8 @@
 
 import os
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any
+
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -23,7 +24,7 @@ DATA_AGENT_CACHE_TTL_HOURS = int(os.getenv("DATA_AGENT_CACHE_TTL_HOURS", "24"))
 DATA_PATH = DATA_DIR / "pipeline_data.parquet"
 
 # Rules thresholds (configurable)
-RULES_CONFIG: Dict[str, Any] = {
+RULES_CONFIG: dict[str, Any] = {
     "zero_quantity_streak_days": 7,
     "imbalance_threshold_pct": 5.0,
     "ramp_risk_window_days": 30,
@@ -33,20 +34,24 @@ RULES_CONFIG: Dict[str, Any] = {
 USE_DUCKDB_FOR_HEAVY_GROUPBY = True
 DEFAULT_PLANNER = "deterministic"
 
+
 def ensure_directories() -> None:
     """Create required directories if they don't exist."""
     for directory in [DATA_DIR, ARTIFACTS_DIR, CACHE_DIR]:
         directory.mkdir(parents=True, exist_ok=True)
+
 
 def get_cache_dir() -> Path:
     """Get cache directory, creating if needed."""
     ensure_directories()
     return CACHE_DIR
 
+
 def get_artifacts_dir() -> Path:
     """Get artifacts directory, creating if needed."""
     ensure_directories()
     return ARTIFACTS_DIR
+
 
 def get_data_dir() -> Path:
     """Get data directory, creating if needed."""

--- a/src/data_agent/ingest/__init__.py
+++ b/src/data_agent/ingest/__init__.py
@@ -1,0 +1,1 @@
+"""Ingest module for loading and processing datasets."""

--- a/src/data_agent/ingest/dictionary.py
+++ b/src/data_agent/ingest/dictionary.py
@@ -1,0 +1,54 @@
+"""Data dictionary generation and utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import orjson
+import polars as pl
+
+ARTIFACTS = Path("artifacts")
+ARTIFACTS.mkdir(parents=True, exist_ok=True)
+
+
+def build_data_dictionary(lf: pl.LazyFrame) -> dict[str, Any]:
+    """Build a comprehensive data dictionary from a LazyFrame.
+
+    Args:
+        lf: Polars LazyFrame to analyze.
+
+    Returns:
+        Dictionary with schema, null rates, and row count information.
+    """
+    # Get schema without collecting data
+    schema_info = lf.collect_schema()
+    schema = {name: str(dtype) for name, dtype in schema_info.items()}
+    column_names = schema_info.names()
+
+    # Compute row count and null rates
+    row_count_frame = lf.select([pl.len().alias("n_rows")]).collect()
+    n_rows = int(row_count_frame[0, "n_rows"]) if row_count_frame.height > 0 else 0
+
+    if n_rows == 0:
+        null_rates = {c: 0.0 for c in column_names}
+    else:
+        # Compute null rates
+        nulls_frame = (
+            lf.select([pl.col(c).is_null().sum().alias(c) for c in column_names])
+            .with_columns(pl.all().cast(pl.Float64) / max(n_rows, 1))
+            .collect()
+        )
+        null_rates = {c: float(nulls_frame[0, c]) for c in column_names}
+
+    return {"schema": schema, "null_rates": null_rates, "n_rows": n_rows}
+
+
+def write_dictionary(dic: dict[str, Any], path: Path = ARTIFACTS / "data_dictionary.json") -> None:
+    """Write data dictionary to JSON file.
+
+    Args:
+        dic: Dictionary to write.
+        path: Output path for JSON file.
+    """
+    path.write_bytes(orjson.dumps(dic, option=orjson.OPT_INDENT_2))

--- a/src/data_agent/ingest/loader.py
+++ b/src/data_agent/ingest/loader.py
@@ -1,0 +1,65 @@
+"""Dataset loader with auto-download and dtype normalization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+DEFAULT_DATA_PATH = Path("data/data.parquet")
+
+
+def load_dataset(path: str | None, auto: bool) -> pl.LazyFrame:
+    """Return a Polars LazyFrame for the dataset. Does not collect.
+
+    Args:
+        path: Path to parquet file. If None, uses DEFAULT_DATA_PATH.
+        auto: If True and path not found, attempt to download dataset.
+
+    Returns:
+        LazyFrame with normalized dtypes.
+
+    Raises:
+        FileNotFoundError: If path doesn't exist and auto=False.
+    """
+    p = Path(path) if path else DEFAULT_DATA_PATH
+
+    if not p.exists():
+        if not auto:
+            raise FileNotFoundError(f"{p} not found; pass --auto to download")
+        # TODO: download via requests/gdown into p
+        # For now, we'll assume the user provides the data
+        raise FileNotFoundError(f"{p} not found and auto-download not implemented yet")
+
+    lf = pl.scan_parquet(str(p))
+
+    # dtype normalization
+    casts: dict[str, Any] = {
+        "rec_del_sign": pl.Int8,
+        "scheduled_quantity": pl.Float64,
+    }
+
+    # Get column names efficiently
+    column_names = lf.collect_schema().names()
+
+    # Handle eff_gas_day -> Date; handle string or date
+    if "eff_gas_day" in column_names:
+        # Check if it's already a date type by trying to use it
+        try:
+            # If it's already a date, this will work fine
+            lf = lf.with_columns(
+                pl.col("eff_gas_day").cast(pl.Date, strict=False).alias("eff_gas_day")
+            )
+        except Exception:
+            # If it's a string, parse it
+            lf = lf.with_columns(
+                pl.col("eff_gas_day").str.strptime(pl.Date, strict=False).alias("eff_gas_day")
+            )
+
+    # Apply casts for other columns
+    lf = lf.with_columns(
+        [pl.col(k).cast(v, strict=False) for k, v in casts.items() if k in column_names]
+    )
+
+    return lf

--- a/src/data_agent/utils/logging.py
+++ b/src/data_agent/utils/logging.py
@@ -1,18 +1,19 @@
 """Structured logging utilities for data agent."""
 
+import json
 import logging
 import sys
 import uuid
 from datetime import datetime
-from typing import Any, Dict, Optional
-import json
+from typing import Any, Optional
 
 # Global run ID for correlating logs across a single execution
 RUN_ID = str(uuid.uuid4())[:8]
 
+
 class StructuredFormatter(logging.Formatter):
     """Custom formatter that outputs structured JSON logs."""
-    
+
     def format(self, record: logging.LogRecord) -> str:
         """Format log record as structured JSON."""
         log_data = {
@@ -22,75 +23,73 @@ class StructuredFormatter(logging.Formatter):
             "run_id": RUN_ID,
             "module": record.name,
         }
-        
+
         # Add extra fields if present
         if hasattr(record, "extra_fields"):
             log_data.update(record.extra_fields)
-            
+
         # Add timing information if present
         if hasattr(record, "duration_ms"):
             log_data["duration_ms"] = record.duration_ms
-            
+
         # Add operation context if present
         if hasattr(record, "operation"):
             log_data["operation"] = record.operation
-            
+
         return json.dumps(log_data, default=str)
+
 
 def setup_logging(level: str = "INFO", structured: bool = True) -> logging.Logger:
     """
     Set up structured logging for the data agent.
-    
+
     Args:
         level: Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
         structured: Whether to use structured JSON format
-        
+
     Returns:
         Configured logger instance
     """
     # Get root logger for data_agent
     logger = logging.getLogger("data_agent")
-    
+
     # Clear any existing handlers
     logger.handlers.clear()
-    
+
     # Set level
     numeric_level = getattr(logging, level.upper(), logging.INFO)
     logger.setLevel(numeric_level)
-    
+
     # Create console handler
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(numeric_level)
-    
+
     # Set formatter
     if structured:
         formatter = StructuredFormatter()
     else:
-        formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        )
-    
+        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
     handler.setFormatter(formatter)
     logger.addHandler(handler)
-    
+
     # Prevent duplicate logs
     logger.propagate = False
-    
+
     return logger
+
 
 def get_logger(name: str) -> logging.Logger:
     """Get a logger for a specific module."""
     return logging.getLogger(f"data_agent.{name}")
 
+
 def log_operation(
-    logger: logging.Logger,
-    operation: str,
-    duration_ms: Optional[float] = None,
-    **extra_fields: Any
+    logger: logging.Logger, operation: str, duration_ms: Optional[float] = None, **extra_fields: Any
 ) -> None:
     """
     Log an operation with timing and extra context.
-    
+
     Args:
         logger: Logger instance
         operation: Name of the operation
@@ -104,22 +103,18 @@ def log_operation(
         lno=0,
         msg=f"Operation: {operation}",
         args=(),
-        exc_info=None
+        exc_info=None,
     )
-    
+
     record.operation = operation
     if duration_ms is not None:
         record.duration_ms = duration_ms
     if extra_fields:
         record.extra_fields = extra_fields
-        
+
     logger.handle(record)
+
 
 def log_timing(logger: logging.Logger, stage: str, duration_ms: float) -> None:
     """Log timing information for a stage."""
-    log_operation(
-        logger, 
-        f"timing.{stage}", 
-        duration_ms=duration_ms,
-        stage=stage
-    )
+    log_operation(logger, f"timing.{stage}", duration_ms=duration_ms, stage=stage)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,11 @@
 """Tests for CLI interface."""
 
-import pytest
 from typer.testing import CliRunner
+
 from data_agent.cli import app
 
 runner = CliRunner()
+
 
 def test_cli_help():
     """Test that CLI help works."""
@@ -13,31 +14,43 @@ def test_cli_help():
     assert "SynMax Data Agent" in result.stdout
     assert "Natural language queries over gas pipeline data" in result.stdout
 
+
 def test_load_command_help():
     """Test load command help."""
     result = runner.invoke(app, ["load", "--help"])
     assert result.exit_code == 0
     assert "Load dataset from --path or auto-download to ./data." in result.stdout
 
+
 def test_load_command_no_args():
     """Test load command with no arguments fails gracefully."""
     result = runner.invoke(app, ["load"])
     assert result.exit_code == 1
-    assert "Please provide --path" in result.stdout
+    assert "not found" in result.stderr
+
 
 def test_load_command_with_path():
-    """Test load command with path."""
+    """Test load command with non-existent path."""
     result = runner.invoke(app, ["load", "--path", "test.parquet"])
-    assert result.exit_code == 0
-    assert "Loading dataset from: test.parquet" in result.stdout
-    assert "Loaded dataset (placeholder)" in result.stdout
+    assert result.exit_code == 1
+    assert "not found" in result.stderr
+
 
 def test_load_command_with_auto():
-    """Test load command with auto flag."""
+    """Test load command with auto flag and non-existent file."""
     result = runner.invoke(app, ["load", "--auto"])
+    assert result.exit_code == 1
+    assert "auto-download not implemented" in result.stderr
+
+
+def test_load_command_success():
+    """Test load command with existing golden.parquet file."""
+    result = runner.invoke(app, ["load", "--path", "examples/golden.parquet"])
     assert result.exit_code == 0
-    assert "Auto-downloading dataset" in result.stdout
-    assert "Loaded dataset (placeholder)" in result.stdout
+    assert "Loaded dataset from: examples/golden.parquet" in result.stdout
+    assert "Rows: 1,000" in result.stdout
+    assert "Data dictionary written to:" in result.stdout
+
 
 def test_ask_command():
     """Test ask command."""
@@ -47,17 +60,20 @@ def test_ask_command():
     assert "Using planner: deterministic" in result.stdout
     assert "Answer (placeholder)" in result.stdout
 
+
 def test_ask_command_with_planner():
     """Test ask command with custom planner."""
     result = runner.invoke(app, ["ask", "test question", "--planner", "llm"])
     assert result.exit_code == 0
     assert "Using planner: llm" in result.stdout
 
+
 def test_ask_command_with_export():
     """Test ask command with export option."""
     result = runner.invoke(app, ["ask", "test question", "--export", "output.json"])
     assert result.exit_code == 0
     assert "Will export results to: output.json" in result.stdout
+
 
 def test_rules_command():
     """Test rules command."""
@@ -66,12 +82,14 @@ def test_rules_command():
     assert "Running data quality rules" in result.stdout
     assert "Rules scan (placeholder)" in result.stdout
 
+
 def test_rules_command_with_options():
     """Test rules command with pipeline and since options."""
     result = runner.invoke(app, ["rules", "--pipeline", "ANR", "--since", "2022-01-01"])
     assert result.exit_code == 0
     assert "Filtering by pipeline: ANR" in result.stdout
     assert "Since date: 2022-01-01" in result.stdout
+
 
 def test_metrics_command_valid():
     """Test metrics command with valid metric name."""
@@ -80,11 +98,13 @@ def test_metrics_command_valid():
     assert "Computing metric: ramp_risk" in result.stdout
     assert "Metric ramp_risk (placeholder)" in result.stdout
 
+
 def test_metrics_command_invalid():
     """Test metrics command with invalid metric name."""
     result = runner.invoke(app, ["metrics", "--name", "invalid_metric"])
     assert result.exit_code == 1
     assert "Invalid metric" in result.stdout
+
 
 def test_events_command():
     """Test events command."""
@@ -93,13 +113,17 @@ def test_events_command():
     assert "Detecting change-point events" in result.stdout
     assert "Showing top 10 events" in result.stdout
 
+
 def test_events_command_with_options():
     """Test events command with options."""
-    result = runner.invoke(app, ["events", "--pipeline", "ANR", "--since", "2022-01-01", "--top", "5"])
+    result = runner.invoke(
+        app, ["events", "--pipeline", "ANR", "--since", "2022-01-01", "--top", "5"]
+    )
     assert result.exit_code == 0
     assert "Pipeline: ANR" in result.stdout
     assert "Since: 2022-01-01" in result.stdout
     assert "Showing top 5 events" in result.stdout
+
 
 def test_cluster_command_valid():
     """Test cluster command with valid entity type."""
@@ -108,11 +132,13 @@ def test_cluster_command_valid():
     assert "Clustering loc entities into 8 clusters" in result.stdout
     assert "Clustered loc entities (placeholder)" in result.stdout
 
+
 def test_cluster_command_invalid():
     """Test cluster command with invalid entity type."""
     result = runner.invoke(app, ["cluster", "--entity-type", "invalid"])
     assert result.exit_code == 1
     assert "Invalid entity type" in result.stdout
+
 
 def test_cache_command_clear():
     """Test cache clear command."""
@@ -120,17 +146,20 @@ def test_cache_command_clear():
     assert result.exit_code == 0
     assert "Cache cleared" in result.stdout
 
+
 def test_cache_command_stats():
     """Test cache stats command."""
     result = runner.invoke(app, ["cache", "--stats"])
     assert result.exit_code == 0
     assert "Cache statistics (placeholder)" in result.stdout
 
+
 def test_cache_command_conflicting_options():
     """Test cache command with conflicting options."""
     result = runner.invoke(app, ["cache", "--clear", "--stats"])
     assert result.exit_code == 1
     assert "Cannot use --clear and --stats together" in result.stdout
+
 
 def test_cache_command_no_options():
     """Test cache command with no options."""

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,163 @@
+"""Tests for the ingest module."""
+
+import tempfile
+from pathlib import Path
+
+import orjson
+import polars as pl
+import pytest
+
+from data_agent.ingest.dictionary import build_data_dictionary, write_dictionary
+from data_agent.ingest.loader import load_dataset
+
+
+@pytest.fixture
+def sample_data():
+    """Create sample test data."""
+    return pl.DataFrame(
+        {
+            "pipeline_name": ["Test Pipeline"] * 10,
+            "loc_name": ["Location A"] * 5 + ["Location B"] * 5,
+            "connecting_pipeline": ["Connecting"] * 10,
+            "connecting_entity": ["Entity"] * 10,
+            "rec_del_sign": [1, -1] * 5,
+            "category_short": ["LDC"] * 10,
+            "country_name": ["USA"] * 10,
+            "state_abb": ["TX"] * 10,
+            "county_name": ["Test County"] * 10,
+            "latitude": [32.0] * 5 + [None] * 5,  # Some nulls
+            "longitude": [-97.0] * 5 + [None] * 5,  # Some nulls
+            "eff_gas_day": ["2022-01-01", "2022-01-02"] * 5,
+            "scheduled_quantity": [1000.0, 2000.0, 0.0, 1500.0, 3000.0] * 2,
+        }
+    )
+
+
+@pytest.fixture
+def temp_parquet(sample_data):
+    """Create a temporary parquet file with sample data."""
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        sample_data.write_parquet(f.name)
+        yield f.name
+    # Cleanup
+    Path(f.name).unlink(missing_ok=True)
+
+
+class TestLoader:
+    """Tests for the loader module."""
+
+    def test_load_dataset_existing_file(self, temp_parquet):
+        """Test loading an existing parquet file."""
+        lf = load_dataset(temp_parquet, auto=False)
+
+        # Verify it's a LazyFrame
+        assert isinstance(lf, pl.LazyFrame)
+
+        # Collect to verify structure
+        df = lf.collect()
+        assert df.shape[0] == 10
+        assert "pipeline_name" in df.columns
+
+        # Check dtype normalization
+        assert df["rec_del_sign"].dtype == pl.Int8
+        assert df["scheduled_quantity"].dtype == pl.Float64
+        assert df["eff_gas_day"].dtype == pl.Date
+
+    def test_load_dataset_missing_file_no_auto(self):
+        """Test that missing file raises error when auto=False."""
+        with pytest.raises(FileNotFoundError, match="not found; pass --auto to download"):
+            load_dataset("nonexistent.parquet", auto=False)
+
+    def test_load_dataset_missing_file_with_auto(self):
+        """Test that missing file with auto=True raises error (not implemented)."""
+        with pytest.raises(FileNotFoundError, match="auto-download not implemented"):
+            load_dataset("nonexistent.parquet", auto=True)
+
+    def test_load_dataset_none_path(self):
+        """Test behavior with None path (should use default)."""
+        with pytest.raises(FileNotFoundError):
+            load_dataset(None, auto=False)
+
+
+class TestDictionary:
+    """Tests for the dictionary module."""
+
+    def test_build_data_dictionary(self, temp_parquet):
+        """Test building a data dictionary from a LazyFrame."""
+        lf = load_dataset(temp_parquet, auto=False)
+        data_dict = build_data_dictionary(lf)
+
+        # Check structure
+        assert "schema" in data_dict
+        assert "null_rates" in data_dict
+        assert "n_rows" in data_dict
+
+        # Check values
+        assert data_dict["n_rows"] == 10
+        assert len(data_dict["schema"]) == 13  # All columns
+
+        # Check null rates
+        assert data_dict["null_rates"]["pipeline_name"] == 0.0  # No nulls
+        assert data_dict["null_rates"]["latitude"] == 0.5  # 50% nulls
+        assert data_dict["null_rates"]["longitude"] == 0.5  # 50% nulls
+
+        # Check schema types
+        assert "Int8" in data_dict["schema"]["rec_del_sign"]
+        assert "Float64" in data_dict["schema"]["scheduled_quantity"]
+        assert "Date" in data_dict["schema"]["eff_gas_day"]
+
+    def test_build_data_dictionary_empty_frame(self):
+        """Test data dictionary with empty frame."""
+        empty_lf = pl.LazyFrame(
+            {"col1": [], "col2": []}, schema={"col1": pl.String, "col2": pl.Int64}
+        )
+
+        data_dict = build_data_dictionary(empty_lf)
+
+        assert data_dict["n_rows"] == 0
+        assert data_dict["null_rates"]["col1"] == 0.0
+        assert data_dict["null_rates"]["col2"] == 0.0
+        assert len(data_dict["schema"]) == 2
+
+    def test_write_dictionary(self, temp_parquet):
+        """Test writing dictionary to JSON file."""
+        lf = load_dataset(temp_parquet, auto=False)
+        data_dict = build_data_dictionary(lf)
+
+        # Use temporary directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            test_path = Path(temp_dir) / "test_dictionary.json"
+            write_dictionary(data_dict, test_path)
+
+            # Verify file exists and is valid JSON
+            assert test_path.exists()
+
+            # Read back and verify content
+            content = orjson.loads(test_path.read_bytes())
+            assert content["n_rows"] == 10
+            assert "schema" in content
+            assert "null_rates" in content
+
+
+class TestIntegration:
+    """Integration tests for the full ingest workflow."""
+
+    def test_full_workflow(self, temp_parquet):
+        """Test the complete load -> dictionary workflow."""
+        # Load dataset
+        lf = load_dataset(temp_parquet, auto=False)
+
+        # Build dictionary
+        data_dict = build_data_dictionary(lf)
+
+        # Verify example values from the task specification
+        assert data_dict["n_rows"] > 0
+        assert len(data_dict["null_rates"]) == len(data_dict["schema"])
+
+        # All null rates should be between 0 and 1
+        for rate in data_dict["null_rates"].values():
+            assert 0.0 <= rate <= 1.0
+
+        # Schema should have string type names
+        for dtype_str in data_dict["schema"].values():
+            assert isinstance(dtype_str, str)


### PR DESCRIPTION
**Steps**

* Implement `load_dataset(path: str|None, auto: bool) -> pl.LazyFrame`.
* Auto-download if `auto=True` and `path` None; save to `./data/data.parquet`.
* Normalize dtypes: `eff_gas_day` → Date, `rec_del_sign` → Int8, `scheduled_quantity` → Float64.
* Implement `build_data_dictionary(lf: pl.LazyFrame) -> dict` and write JSON to `artifacts/data_dictionary.json`.

**Acceptance**

* `agent load --path examples/golden.parquet` prints schema + writes `artifacts/data_dictionary.json`.
* Unit tests validate null rates & example values presence.