### PR TITLE
plan schema and deterministic templates

### DIFF
--- a/src/data_agent/core/__init__.py
+++ b/src/data_agent/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core data agent components."""

--- a/src/data_agent/core/plan_schema.py
+++ b/src/data_agent/core/plan_schema.py
@@ -1,0 +1,50 @@
+"""Pydantic schemas for query plans."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class Filter(BaseModel):
+    """A filter operation on a column."""
+
+    column: str
+    op: Literal["=", "in", "between", "is_not_null", "contains"]
+    value: Any
+
+
+class Aggregate(BaseModel):
+    """Aggregation operations with groupby and metrics."""
+
+    groupby: list[str] = Field(default_factory=list)
+    metrics: list[dict[str, str]] = Field(default_factory=list)  # {col, fn}
+
+
+class Resample(BaseModel):
+    """Time-based resampling configuration."""
+
+    freq: str = "1d"
+    on: str = "eff_gas_day"
+
+
+class Sort(BaseModel):
+    """Sorting configuration."""
+
+    by: list[str]
+    desc: bool = True
+    limit: int | None = None
+
+
+class Plan(BaseModel):
+    """Complete query execution plan."""
+
+    filters: list[Filter] = Field(default_factory=list)
+    resample: Resample | None = None
+    aggregate: Aggregate | None = None
+    sort: Sort | None = None
+    op: Literal["metric_compute", "changepoint", "cluster", "rules_scan", None] | None = None
+    op_args: dict[str, Any] = Field(default_factory=dict)
+    evidence: bool = True
+    format: Literal["table", "json"] = "table"

--- a/src/data_agent/core/planner.py
+++ b/src/data_agent/core/planner.py
@@ -1,0 +1,116 @@
+"""Deterministic template-based query planner."""
+
+import re
+
+from .plan_schema import Aggregate, Filter, Plan, Sort
+
+# Pattern definitions for deterministic planning
+_PATTERNS = [
+    # sum deliveries for pipeline on date
+    (
+        re.compile(r"sum of deliveries for (.+) on (\d{4}-\d{2}-\d{2})", re.I),
+        "sum_deliveries_on_date",
+    ),
+    # top N states by total scheduled quantity in year
+    (
+        re.compile(r"top (\d+) states by total scheduled quantity in (\d{4})", re.I),
+        "top_states_year",
+    ),
+    # deliveries for pipeline in date range
+    (
+        re.compile(
+            r"deliveries for (.+) between (\d{4}-\d{2}-\d{2}) and (\d{4}-\d{2}-\d{2})", re.I
+        ),
+        "deliveries_date_range",
+    ),
+    # total receipts for pipeline
+    (re.compile(r"total receipts for (.+)", re.I), "total_receipts_pipeline"),
+    # average scheduled quantity by state
+    (re.compile(r"average scheduled quantity by state", re.I), "avg_scheduled_by_state"),
+]
+
+
+def plan(q: str, deterministic: bool = True) -> Plan:
+    """Create a query plan from natural language input.
+
+    Args:
+        q: Natural language query string
+        deterministic: If True, use template-based planning (only option for now)
+
+    Returns:
+        Plan object representing the query execution plan
+
+    Raises:
+        ValueError: If no matching pattern is found for deterministic planning
+    """
+    if not deterministic:
+        raise NotImplementedError("LLM-based planning not yet implemented")
+
+    for rx, key in _PATTERNS:
+        m = rx.search(q)
+        if not m:
+            continue
+
+        if key == "sum_deliveries_on_date":
+            pipeline, d = m.group(1).strip(), m.group(2)
+            return Plan(
+                filters=[
+                    Filter(column="pipeline_name", op="=", value=pipeline),
+                    Filter(column="rec_del_sign", op="=", value=-1),  # -1 for deliveries
+                    Filter(column="eff_gas_day", op="between", value=[d, d]),
+                ],
+                aggregate=Aggregate(
+                    groupby=[], metrics=[{"col": "scheduled_quantity", "fn": "sum"}]
+                ),
+            )
+
+        elif key == "top_states_year":
+            n, year = int(m.group(1)), m.group(2)
+            return Plan(
+                filters=[
+                    Filter(
+                        column="eff_gas_day", op="between", value=[f"{year}-01-01", f"{year}-12-31"]
+                    )
+                ],
+                aggregate=Aggregate(
+                    groupby=["state_abb"], metrics=[{"col": "scheduled_quantity", "fn": "sum"}]
+                ),
+                sort=Sort(by=["sum_scheduled_quantity"], desc=True, limit=n),
+            )
+
+        elif key == "deliveries_date_range":
+            pipeline, start_date, end_date = m.group(1).strip(), m.group(2), m.group(3)
+            return Plan(
+                filters=[
+                    Filter(column="pipeline_name", op="=", value=pipeline),
+                    Filter(column="rec_del_sign", op="=", value=-1),  # -1 for deliveries
+                    Filter(column="eff_gas_day", op="between", value=[start_date, end_date]),
+                ],
+                aggregate=Aggregate(
+                    groupby=["eff_gas_day"], metrics=[{"col": "scheduled_quantity", "fn": "sum"}]
+                ),
+                sort=Sort(by=["eff_gas_day"], desc=False),
+            )
+
+        elif key == "total_receipts_pipeline":
+            pipeline = m.group(1).strip()
+            return Plan(
+                filters=[
+                    Filter(column="pipeline_name", op="=", value=pipeline),
+                    Filter(column="rec_del_sign", op="=", value=1),  # 1 for receipts
+                ],
+                aggregate=Aggregate(
+                    groupby=[], metrics=[{"col": "scheduled_quantity", "fn": "sum"}]
+                ),
+            )
+
+        elif key == "avg_scheduled_by_state":
+            return Plan(
+                aggregate=Aggregate(
+                    groupby=["state_abb"], metrics=[{"col": "scheduled_quantity", "fn": "avg"}]
+                ),
+                sort=Sort(by=["avg_scheduled_quantity"], desc=True),
+            )
+
+    # Fallback: return minimal plan if no pattern matches
+    return Plan()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,8 +64,9 @@ def test_ask_command():
 def test_ask_command_with_planner():
     """Test ask command with custom planner."""
     result = runner.invoke(app, ["ask", "test question", "--planner", "llm"])
-    assert result.exit_code == 0
+    assert result.exit_code == 1  # Should fail because LLM planner is not implemented
     assert "Using planner: llm" in result.stdout
+    assert "LLM-based planning not yet implemented" in result.stderr
 
 
 def test_ask_command_with_export():

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,172 @@
+"""Tests for the deterministic planner."""
+
+import pytest
+
+from data_agent.core.plan_schema import Filter, Plan
+from data_agent.core.planner import plan
+
+
+class TestDeterministicPlanner:
+    """Test cases for deterministic template-based planning."""
+
+    def test_sum_deliveries_on_date(self):
+        """Test pattern: sum of deliveries for pipeline on date."""
+        query = "sum of deliveries for ANR on 2022-01-01"
+        result = plan(query, deterministic=True)
+
+        assert isinstance(result, Plan)
+        assert len(result.filters) == 3
+        assert result.filters[0] == Filter(column="pipeline_name", op="=", value="ANR")
+        assert result.filters[1] == Filter(column="rec_del_sign", op="=", value=-1)
+        assert result.filters[2] == Filter(
+            column="eff_gas_day", op="between", value=["2022-01-01", "2022-01-01"]
+        )
+        assert result.aggregate is not None
+        assert result.aggregate.groupby == []
+        assert result.aggregate.metrics == [{"col": "scheduled_quantity", "fn": "sum"}]
+
+        # Validate JSON serialization
+        json_data = result.model_dump()
+        assert json_data["filters"][0]["column"] == "pipeline_name"
+        assert json_data["aggregate"]["metrics"][0]["fn"] == "sum"
+
+    def test_top_states_by_quantity_year(self):
+        """Test pattern: top N states by total scheduled quantity in year."""
+        query = "top 5 states by total scheduled quantity in 2022"
+        result = plan(query, deterministic=True)
+
+        assert isinstance(result, Plan)
+        assert len(result.filters) == 1
+        assert result.filters[0] == Filter(
+            column="eff_gas_day", op="between", value=["2022-01-01", "2022-12-31"]
+        )
+        assert result.aggregate is not None
+        assert result.aggregate.groupby == ["state_abb"]
+        assert result.aggregate.metrics == [{"col": "scheduled_quantity", "fn": "sum"}]
+        assert result.sort is not None
+        assert result.sort.by == ["sum_scheduled_quantity"]
+        assert result.sort.desc is True
+        assert result.sort.limit == 5
+
+        # Validate JSON serialization
+        json_data = result.model_dump()
+        assert json_data["sort"]["limit"] == 5
+        assert json_data["aggregate"]["groupby"] == ["state_abb"]
+
+    def test_deliveries_date_range(self):
+        """Test pattern: deliveries for pipeline between dates."""
+        query = "deliveries for TGP between 2022-01-01 and 2022-01-31"
+        result = plan(query, deterministic=True)
+
+        assert isinstance(result, Plan)
+        assert len(result.filters) == 3
+        assert result.filters[0] == Filter(column="pipeline_name", op="=", value="TGP")
+        assert result.filters[1] == Filter(column="rec_del_sign", op="=", value=-1)
+        assert result.filters[2] == Filter(
+            column="eff_gas_day", op="between", value=["2022-01-01", "2022-01-31"]
+        )
+        assert result.aggregate is not None
+        assert result.aggregate.groupby == ["eff_gas_day"]
+        assert result.aggregate.metrics == [{"col": "scheduled_quantity", "fn": "sum"}]
+        assert result.sort is not None
+        assert result.sort.by == ["eff_gas_day"]
+        assert result.sort.desc is False
+
+        # Validate JSON serialization
+        json_data = result.model_dump()
+        assert json_data["filters"][2]["value"] == ["2022-01-01", "2022-01-31"]
+
+    def test_total_receipts_pipeline(self):
+        """Test pattern: total receipts for pipeline."""
+        query = "total receipts for Kinder Morgan"
+        result = plan(query, deterministic=True)
+
+        assert isinstance(result, Plan)
+        assert len(result.filters) == 2
+        assert result.filters[0] == Filter(column="pipeline_name", op="=", value="Kinder Morgan")
+        assert result.filters[1] == Filter(column="rec_del_sign", op="=", value=1)  # 1 for receipts
+        assert result.aggregate is not None
+        assert result.aggregate.groupby == []
+        assert result.aggregate.metrics == [{"col": "scheduled_quantity", "fn": "sum"}]
+
+        # Validate JSON serialization
+        json_data = result.model_dump()
+        assert json_data["filters"][1]["value"] == 1
+
+    def test_average_scheduled_by_state(self):
+        """Test pattern: average scheduled quantity by state."""
+        query = "average scheduled quantity by state"
+        result = plan(query, deterministic=True)
+
+        assert isinstance(result, Plan)
+        assert len(result.filters) == 0  # No filters for this pattern
+        assert result.aggregate is not None
+        assert result.aggregate.groupby == ["state_abb"]
+        assert result.aggregate.metrics == [{"col": "scheduled_quantity", "fn": "avg"}]
+        assert result.sort is not None
+        assert result.sort.by == ["avg_scheduled_quantity"]
+        assert result.sort.desc is True
+
+        # Validate JSON serialization
+        json_data = result.model_dump()
+        assert json_data["aggregate"]["metrics"][0]["fn"] == "avg"
+
+    def test_case_insensitive_matching(self):
+        """Test that patterns work with different cases."""
+        queries = [
+            "SUM OF DELIVERIES FOR ANR ON 2022-01-01",
+            "Sum Of Deliveries For ANR On 2022-01-01",
+            "sum of deliveries for anr on 2022-01-01",
+        ]
+
+        for query in queries:
+            result = plan(query, deterministic=True)
+            assert isinstance(result, Plan)
+            assert len(result.filters) == 3
+            assert result.filters[0].value in [
+                "ANR",
+                "anr",
+            ]  # Pipeline name preserves case from input
+
+    def test_no_match_returns_empty_plan(self):
+        """Test that unmatched queries return an empty plan."""
+        query = "this query does not match any pattern"
+        result = plan(query, deterministic=True)
+
+        assert isinstance(result, Plan)
+        assert len(result.filters) == 0
+        assert result.aggregate is None
+        assert result.sort is None
+        assert result.op is None
+
+    def test_llm_planning_not_implemented(self):
+        """Test that LLM-based planning raises NotImplementedError."""
+        query = "any query"
+        with pytest.raises(NotImplementedError, match="LLM-based planning not yet implemented"):
+            plan(query, deterministic=False)
+
+    def test_plan_schema_defaults(self):
+        """Test that Plan schema has correct defaults."""
+        empty_plan = Plan()
+
+        assert empty_plan.filters == []
+        assert empty_plan.resample is None
+        assert empty_plan.aggregate is None
+        assert empty_plan.sort is None
+        assert empty_plan.op is None
+        assert empty_plan.op_args == {}
+        assert empty_plan.evidence is True
+        assert empty_plan.format == "table"
+
+    def test_complex_pipeline_names(self):
+        """Test that complex pipeline names are handled correctly."""
+        query = "sum of deliveries for Texas Eastern Transmission Pipeline on 2022-01-01"
+        result = plan(query, deterministic=True)
+
+        assert isinstance(result, Plan)
+        assert result.filters[0].value == "Texas Eastern Transmission Pipeline"
+
+        # Test with abbreviations
+        query2 = "sum of deliveries for TGP-100 on 2022-01-01"
+        result2 = plan(query2, deterministic=True)
+        assert result2.filters[0].value == "TGP-100"


### PR DESCRIPTION
**Steps**

* Define Pydantic classes: `Filter`, `Aggregate`, `Resample`, `Sort`, `Plan`.
* Deterministic template mapper: regex/rule-based map from a few NL forms → `Plan`.
* Add `planner.plan(q: str, deterministic=True) -> Plan`.

**Acceptance**

* Unit tests: 5 prompts produce valid `Plan` instances and expected JSON.
* CLI: `agent ask "sum of deliveries for ANR on 2022-01-01" --planner deterministic --dry-run` prints Plan JSON.
