### PR TITLE
added caching and fixed test that caused entire dataset to be read

### DIFF
--- a/src/data_agent/cache/__init__.py
+++ b/src/data_agent/cache/__init__.py
@@ -1,0 +1,5 @@
+"""Caching module for query results."""
+
+from .cache import CacheManager
+
+__all__ = ["CacheManager"]

--- a/src/data_agent/cache/cache.py
+++ b/src/data_agent/cache/cache.py
@@ -1,0 +1,191 @@
+"""Cache management for query results."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from pathlib import Path
+from typing import Any
+
+import orjson
+import polars as pl
+
+from ..config import CACHE_DIR, DATA_AGENT_CACHE_TTL_HOURS
+from ..core.plan_schema import Plan
+
+
+class CacheManager:
+    """Manages caching of query results with fingerprinting and TTL."""
+
+    def __init__(self, cache_dir: Path | None = None, ttl_hours: int | None = None):
+        """Initialize cache manager.
+
+        Args:
+            cache_dir: Cache directory path (defaults to config)
+            ttl_hours: Time-to-live in hours (defaults to config)
+        """
+        self.cache_dir = cache_dir or CACHE_DIR / "results"
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.ttl_hours = ttl_hours or DATA_AGENT_CACHE_TTL_HOURS
+        self.ttl_seconds = self.ttl_hours * 3600
+
+    def _compute_fingerprint(self, plan: Plan, dataset_digest: str) -> str:
+        """Compute fingerprint from canonical Plan JSON + dataset digest.
+
+        Args:
+            plan: Query plan
+            dataset_digest: Dataset digest string
+
+        Returns:
+            Hexadecimal fingerprint string
+        """
+        # Create canonical JSON representation of plan
+        # Use default=str to handle Polars expressions that can't be serialized
+        plan_dict = plan.model_dump()
+        plan_json = orjson.dumps(plan_dict, option=orjson.OPT_SORT_KEYS, default=str).decode(
+            "utf-8"
+        )
+
+        # Combine with dataset digest
+        combined = f"{plan_json}|{dataset_digest}".encode()
+
+        # Compute SHA-256 hash
+        return hashlib.sha256(combined).hexdigest()
+
+    def _get_cache_paths(self, fingerprint: str) -> tuple[Path, Path]:
+        """Get cache file paths for a fingerprint.
+
+        Args:
+            fingerprint: Cache fingerprint
+
+        Returns:
+            Tuple of (parquet_path, json_path)
+        """
+        parquet_path = self.cache_dir / f"{fingerprint}.parquet"
+        json_path = self.cache_dir / f"{fingerprint}.json"
+        return parquet_path, json_path
+
+    def _is_cache_valid(self, parquet_path: Path, json_path: Path) -> bool:
+        """Check if cache files exist and are within TTL.
+
+        Args:
+            parquet_path: Path to parquet cache file
+            json_path: Path to JSON cache file
+
+        Returns:
+            True if cache is valid, False otherwise
+        """
+        if not parquet_path.exists() or not json_path.exists():
+            return False
+
+        # Check TTL based on file modification time
+        current_time = time.time()
+        file_mtime = parquet_path.stat().st_mtime
+
+        return (current_time - file_mtime) < self.ttl_seconds
+
+    def get(
+        self, plan: Plan, dataset_digest: str
+    ) -> tuple[pl.DataFrame | None, dict[str, Any] | None]:
+        """Retrieve cached result if available and valid.
+
+        Args:
+            plan: Query plan
+            dataset_digest: Dataset digest string
+
+        Returns:
+            Tuple of (DataFrame, evidence_dict) or (None, None) if not cached
+        """
+        fingerprint = self._compute_fingerprint(plan, dataset_digest)
+        parquet_path, json_path = self._get_cache_paths(fingerprint)
+
+        if not self._is_cache_valid(parquet_path, json_path):
+            return None, None
+
+        try:
+            # Load cached DataFrame
+            df = pl.read_parquet(parquet_path)
+
+            # Load cached evidence
+            with open(json_path, "rb") as f:
+                evidence = orjson.loads(f.read())
+
+            # Verify that the evidence contains the correct fingerprint
+            if evidence.get("cache", {}).get("fingerprint") != fingerprint:
+                return None, None
+
+            return df, evidence
+        except Exception:
+            # If loading fails, return None (cache miss)
+            return None, None
+
+    def put(
+        self, plan: Plan, dataset_digest: str, df: pl.DataFrame, evidence: dict[str, Any]
+    ) -> None:
+        """Store result in cache.
+
+        Args:
+            plan: Query plan
+            dataset_digest: Dataset digest string
+            df: Result DataFrame
+            evidence: Evidence dictionary
+        """
+        fingerprint = self._compute_fingerprint(plan, dataset_digest)
+        parquet_path, json_path = self._get_cache_paths(fingerprint)
+
+        try:
+            # Store DataFrame
+            df.write_parquet(parquet_path)
+
+            # Store evidence with cache metadata
+            cache_evidence = evidence.copy()
+            cache_evidence["cache"] = {
+                "hit": False,  # This is a cache put, not a hit
+                "fingerprint": fingerprint,
+                "ttl_hours": self.ttl_hours,
+                "cached_at": time.time(),
+            }
+
+            with open(json_path, "wb") as f:
+                f.write(orjson.dumps(cache_evidence, option=orjson.OPT_INDENT_2))
+
+        except Exception:
+            # If storing fails, silently continue (non-critical)
+            pass
+
+    def clear(self) -> None:
+        """Clear all cached results."""
+        if self.cache_dir.exists():
+            for file_path in self.cache_dir.glob("*"):
+                file_path.unlink()
+
+    def stats(self) -> dict[str, Any]:
+        """Get cache statistics.
+
+        Returns:
+            Dictionary with cache statistics
+        """
+        if not self.cache_dir.exists():
+            return {"total_files": 0, "total_size_bytes": 0, "valid_entries": 0}
+
+        files = list(self.cache_dir.glob("*"))
+        parquet_files = [f for f in files if f.suffix == ".parquet"]
+        json_files = [f for f in files if f.suffix == ".json"]
+
+        total_size = sum(f.stat().st_size for f in files)
+
+        # Count valid entries (both parquet and json exist and are within TTL)
+        valid_entries = 0
+        for parquet_file in parquet_files:
+            json_file = parquet_file.with_suffix(".json")
+            if self._is_cache_valid(parquet_file, json_file):
+                valid_entries += 1
+
+        return {
+            "total_files": len(files),
+            "parquet_files": len(parquet_files),
+            "json_files": len(json_files),
+            "total_size_bytes": total_size,
+            "valid_entries": valid_entries,
+            "ttl_hours": self.ttl_hours,
+        }

--- a/src/data_agent/core/planner.py
+++ b/src/data_agent/core/planner.py
@@ -50,7 +50,17 @@ PLAN_FUNCTION_SCHEMA = {
                         "column": {"type": "string", "description": "Column name to filter on"},
                         "op": {
                             "type": "string",
-                            "enum": ["=", "in", "between", "is_not_null", "contains", ">=", ">", "<=", "<"],
+                            "enum": [
+                                "=",
+                                "in",
+                                "between",
+                                "is_not_null",
+                                "contains",
+                                ">=",
+                                ">",
+                                "<=",
+                                "<",
+                            ],
                             "description": "Filter operation",
                         },
                         "value": {"description": "Filter value (can be any type)"},
@@ -168,7 +178,7 @@ def _normalize_plan_data(plan_data: dict[str, Any]) -> dict[str, Any]:
                 if re.match(r"^\d{4}-\d{2}-\d{2}$", value):
                     year, month, day = map(int, value.split("-"))
                     date_val = pl.date(year, month, day)
-                    
+
                     if op == "=":
                         # Convert single date to between range
                         filter_item["op"] = "between"
@@ -196,11 +206,18 @@ def _normalize_plan_data(plan_data: dict[str, Any]) -> dict[str, Any]:
                     else:
                         # For other ops, just convert the value
                         filter_item["value"] = date_val
-                        
+
             # Handle between with date strings
-            elif column == "eff_gas_day" and op == "between" and isinstance(value, list) and len(value) == 2:
+            elif (
+                column == "eff_gas_day"
+                and op == "between"
+                and isinstance(value, list)
+                and len(value) == 2
+            ):
                 if isinstance(value[0], str) and isinstance(value[1], str):
-                    if re.match(r"^\d{4}-\d{2}-\d{2}$", value[0]) and re.match(r"^\d{4}-\d{2}-\d{2}$", value[1]):
+                    if re.match(r"^\d{4}-\d{2}-\d{2}$", value[0]) and re.match(
+                        r"^\d{4}-\d{2}-\d{2}$", value[1]
+                    ):
                         start_year, start_month, start_day = map(int, value[0].split("-"))
                         end_year, end_month, end_day = map(int, value[1].split("-"))
                         filter_item["value"] = [
@@ -226,7 +243,17 @@ def _validate_plan_json(plan_data: dict[str, Any]) -> bool:
             for filter_item in plan_data["filters"]:
                 if filter_item.get("column") not in VALID_COLUMNS:
                     return False
-                if filter_item.get("op") not in ["=", "in", "between", "is_not_null", "contains", ">=", ">", "<=", "<"]:
+                if filter_item.get("op") not in [
+                    "=",
+                    "in",
+                    "between",
+                    "is_not_null",
+                    "contains",
+                    ">=",
+                    ">",
+                    "<=",
+                    "<",
+                ]:
                     return False
 
         # Check aggregate references valid columns

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,213 @@
+"""Tests for caching functionality."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import polars as pl
+
+from data_agent.cache import CacheManager
+from data_agent.core.plan_schema import Filter, Plan
+
+
+class TestCacheManager:
+    """Test cache manager functionality."""
+
+    def test_init(self):
+        """Test cache manager initialization."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_dir = Path(temp_dir) / "cache"
+            cache_manager = CacheManager(cache_dir=cache_dir, ttl_hours=1)
+
+            assert cache_manager.cache_dir == cache_dir
+            assert cache_manager.ttl_hours == 1
+            assert cache_manager.ttl_seconds == 3600
+            assert cache_dir.exists()
+
+    def test_fingerprint_computation(self):
+        """Test fingerprint computation from plan and dataset digest."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_manager = CacheManager(cache_dir=Path(temp_dir) / "cache")
+
+            plan = Plan(filters=[Filter(column="test_col", op="=", value="test")])
+            dataset_digest = "abc123"
+
+            fingerprint1 = cache_manager._compute_fingerprint(plan, dataset_digest)
+            fingerprint2 = cache_manager._compute_fingerprint(plan, dataset_digest)
+
+            # Same inputs should produce same fingerprint
+            assert fingerprint1 == fingerprint2
+            assert len(fingerprint1) == 64  # SHA-256 hex length
+
+            # Different plan should produce different fingerprint
+            plan2 = Plan(filters=[Filter(column="other_col", op="=", value="test")])
+            fingerprint3 = cache_manager._compute_fingerprint(plan2, dataset_digest)
+            assert fingerprint1 != fingerprint3
+
+            # Different dataset digest should produce different fingerprint
+            fingerprint4 = cache_manager._compute_fingerprint(plan, "xyz789")
+            assert fingerprint1 != fingerprint4
+
+    def test_cache_put_and_get(self):
+        """Test storing and retrieving from cache."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_manager = CacheManager(cache_dir=Path(temp_dir) / "cache")
+
+            plan = Plan(filters=[Filter(column="test_col", op="=", value="test")])
+            dataset_digest = "abc123"
+
+            # Create test data
+            df = pl.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
+            evidence = {"test": "evidence", "cache": {"hit": False}}
+
+            # Initially should not be in cache
+            cached_df, cached_evidence = cache_manager.get(plan, dataset_digest)
+            assert cached_df is None
+            assert cached_evidence is None
+
+            # Store in cache
+            cache_manager.put(plan, dataset_digest, df, evidence)
+
+            # Should now be retrievable
+            cached_df, cached_evidence = cache_manager.get(plan, dataset_digest)
+            assert cached_df is not None
+            assert cached_evidence is not None
+            assert cached_df.equals(df)
+
+            # Check that the evidence matches (accounting for cache metadata)
+            assert cached_evidence["test"] == evidence["test"]
+            assert "cache" in cached_evidence
+            assert "fingerprint" in cached_evidence["cache"]
+            assert "ttl_hours" in cached_evidence["cache"]
+            assert "cached_at" in cached_evidence["cache"]
+
+    def test_cache_ttl_expiration(self):
+        """Test cache TTL expiration."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Use very short TTL for testing
+            cache_manager = CacheManager(
+                cache_dir=Path(temp_dir) / "cache", ttl_hours=0.0001
+            )  # ~0.36 seconds
+
+            plan = Plan(filters=[Filter(column="test_col", op="=", value="test")])
+            dataset_digest = "abc123"
+
+            df = pl.DataFrame({"col1": [1, 2, 3]})
+            evidence = {"test": "evidence"}
+
+            # Store in cache
+            cache_manager.put(plan, dataset_digest, df, evidence)
+
+            # Should be available immediately
+            cached_df, cached_evidence = cache_manager.get(plan, dataset_digest)
+            assert cached_df is not None
+
+            # Wait for TTL to expire
+            import time
+
+            time.sleep(0.5)
+
+            # Should no longer be available
+            cached_df, cached_evidence = cache_manager.get(plan, dataset_digest)
+            assert cached_df is None
+            assert cached_evidence is None
+
+    def test_cache_clear(self):
+        """Test cache clearing."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_manager = CacheManager(cache_dir=Path(temp_dir) / "cache")
+
+            plan = Plan(filters=[Filter(column="test_col", op="=", value="test")])
+            dataset_digest = "abc123"
+
+            df = pl.DataFrame({"col1": [1, 2, 3]})
+            evidence = {"test": "evidence"}
+
+            # Store in cache
+            cache_manager.put(plan, dataset_digest, df, evidence)
+
+            # Should be available
+            cached_df, cached_evidence = cache_manager.get(plan, dataset_digest)
+            assert cached_df is not None
+
+            # Clear cache
+            cache_manager.clear()
+
+            # Should no longer be available
+            cached_df, cached_evidence = cache_manager.get(plan, dataset_digest)
+            assert cached_df is None
+
+    def test_cache_stats(self):
+        """Test cache statistics."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_manager = CacheManager(cache_dir=Path(temp_dir) / "cache")
+
+            # Empty cache stats
+            stats = cache_manager.stats()
+            assert stats["total_files"] == 0
+            assert stats["valid_entries"] == 0
+
+            # Add some entries
+            plan1 = Plan(filters=[Filter(column="col1", op="=", value="val1")])
+            plan2 = Plan(filters=[Filter(column="col2", op="=", value="val2")])
+
+            df1 = pl.DataFrame({"a": [1, 2]})
+            df2 = pl.DataFrame({"b": [3, 4]})
+            evidence = {"test": "evidence"}
+
+            cache_manager.put(plan1, "digest1", df1, evidence)
+            cache_manager.put(plan2, "digest2", df2, evidence)
+
+            # Check stats
+            stats = cache_manager.stats()
+            assert stats["total_files"] == 4  # 2 parquet + 2 json
+            assert stats["parquet_files"] == 2
+            assert stats["json_files"] == 2
+            assert stats["valid_entries"] == 2
+            assert stats["ttl_hours"] == 24  # default
+
+    def test_cache_invalid_files(self):
+        """Test handling of invalid cache files."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_manager = CacheManager(cache_dir=Path(temp_dir) / "cache")
+
+            plan = Plan(filters=[Filter(column="test_col", op="=", value="test")])
+            dataset_digest = "abc123"
+
+            # Create invalid cache files
+            parquet_path, json_path = cache_manager._get_cache_paths(
+                cache_manager._compute_fingerprint(plan, dataset_digest)
+            )
+
+            # Create empty files (invalid)
+            parquet_path.touch()
+            json_path.touch()
+
+            # Should return None due to invalid files
+            cached_df, cached_evidence = cache_manager.get(plan, dataset_digest)
+            assert cached_df is None
+            assert cached_evidence is None
+
+    def test_cache_put_failure_handling(self):
+        """Test that cache put failures are handled gracefully."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_manager = CacheManager(cache_dir=Path(temp_dir) / "cache")
+
+            plan = Plan(filters=[Filter(column="test_col", op="=", value="test")])
+            dataset_digest = "abc123"
+
+            # Create a DataFrame that might cause issues
+            df = pl.DataFrame({"col1": [1, 2, 3]})
+            evidence = {"test": "evidence"}
+
+            # Mock a failure in the put method by patching the write_parquet method
+            with patch.object(df, "write_parquet") as mock_write:
+                mock_write.side_effect = Exception("Mocked failure")
+
+                # Should not raise exception
+                cache_manager.put(plan, dataset_digest, df, evidence)
+
+                # Should not be in cache due to failure
+                cached_df, cached_evidence = cache_manager.get(plan, dataset_digest)
+                assert cached_df is None
+                assert cached_evidence is None

--- a/tests/test_cache_integration.py
+++ b/tests/test_cache_integration.py
@@ -1,0 +1,161 @@
+"""Integration tests for caching with executor."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import polars as pl
+
+from data_agent.cache import CacheManager
+from data_agent.core.executor import run
+from data_agent.core.plan_schema import Filter, Plan
+
+
+class TestCacheIntegration:
+    """Test cache integration with executor."""
+
+    def test_executor_cache_hit(self):
+        """Test that executor returns cached results on repeated queries."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_manager = CacheManager(cache_dir=Path(temp_dir) / "cache")
+
+            # Create test data
+            test_data = pl.DataFrame(
+                {
+                    "col1": [1, 2, 3, 4, 5],
+                    "col2": ["a", "b", "c", "d", "e"],
+                    "value": [10, 20, 30, 40, 50],
+                }
+            )
+
+            # Create a LazyFrame
+            lf = test_data.lazy()
+
+            # Create a simple plan
+            plan = Plan(
+                filters=[Filter(column="col1", op="=", value=3)],
+                aggregate={"groupby": [], "metrics": [{"col": "value", "fn": "sum"}]},
+            )
+
+            # Mock the dataset digest and rules engine
+            with patch("data_agent.core.executor._digest", return_value="test_digest"), patch(
+                "data_agent.core.evidence.run_rules", return_value={}
+            ):
+                # First execution - should be cache miss
+                answer1 = run(lf, plan, cache_manager)
+
+                # Second execution - should be cache hit
+                answer2 = run(lf, plan, cache_manager)
+
+                # Results should be identical
+                assert answer1.table.equals(answer2.table)
+                assert answer1.evidence["rows_out"] == answer2.evidence["rows_out"]
+
+                # First should be cache miss, second should be cache hit
+                assert answer1.evidence["cache"]["hit"] is False
+                assert answer2.evidence["cache"]["hit"] is True
+
+                # Second execution should be faster (though we can't easily test this)
+                # The evidence should show cache hit status
+
+    def test_executor_cache_miss_different_plan(self):
+        """Test that different plans result in cache misses."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_manager = CacheManager(cache_dir=Path(temp_dir) / "cache")
+
+            # Create test data
+            test_data = pl.DataFrame(
+                {
+                    "col1": [1, 2, 3, 4, 5],
+                    "col2": ["a", "b", "c", "d", "e"],
+                    "value": [10, 20, 30, 40, 50],
+                }
+            )
+
+            lf = test_data.lazy()
+
+            # Create two different plans
+            plan1 = Plan(filters=[Filter(column="col1", op="=", value=2)])
+            plan2 = Plan(filters=[Filter(column="col1", op="=", value=3)])
+
+            with patch("data_agent.core.executor._digest", return_value="test_digest"), patch(
+                "data_agent.core.evidence.run_rules", return_value={}
+            ):
+                # Execute first plan
+                answer1 = run(lf, plan1, cache_manager)
+                assert answer1.evidence["cache"]["hit"] is False
+
+                # Execute second plan - should be cache miss due to different plan
+                answer2 = run(lf, plan2, cache_manager)
+                assert answer2.evidence["cache"]["hit"] is False
+
+                # Results should be different
+                assert not answer1.table.equals(answer2.table)
+
+    def test_executor_cache_miss_different_dataset(self):
+        """Test that different dataset digests result in cache misses."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_manager = CacheManager(cache_dir=Path(temp_dir) / "cache")
+
+            # Create test data
+            test_data = pl.DataFrame({"col1": [1, 2, 3, 4, 5], "value": [10, 20, 30, 40, 50]})
+
+            lf = test_data.lazy()
+            plan = Plan(filters=[Filter(column="col1", op="=", value=2)])
+
+            # First execution with one digest
+            with patch("data_agent.core.executor._digest", return_value="digest1"), patch(
+                "data_agent.core.evidence.run_rules", return_value={}
+            ):
+                answer1 = run(lf, plan, cache_manager)
+                assert answer1.evidence["cache"]["hit"] is False
+
+            # Second execution with different digest - should be cache miss
+            with patch("data_agent.core.executor._digest", return_value="digest2"), patch(
+                "data_agent.core.evidence.run_rules", return_value={}
+            ):
+                answer2 = run(lf, plan, cache_manager)
+                # Should be cache miss because different dataset digest
+                assert answer2.evidence["cache"]["hit"] is False
+
+    def test_executor_no_cache_manager(self):
+        """Test that executor works without cache manager."""
+        # Create test data
+        test_data = pl.DataFrame({"col1": [1, 2, 3, 4, 5], "value": [10, 20, 30, 40, 50]})
+
+        lf = test_data.lazy()
+        plan = Plan(filters=[Filter(column="col1", op="=", value=2)])
+
+        # Should work without cache manager
+        with patch("data_agent.core.evidence.run_rules", return_value={}):
+            answer = run(lf, plan, None)
+        assert answer.table is not None
+        assert answer.evidence is not None
+        assert answer.evidence["cache"]["hit"] is False
+
+    def test_cache_evidence_metadata(self):
+        """Test that cached evidence includes proper cache metadata."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_manager = CacheManager(cache_dir=Path(temp_dir) / "cache")
+
+            test_data = pl.DataFrame({"col1": [1, 2, 3], "value": [10, 20, 30]})
+
+            lf = test_data.lazy()
+            plan = Plan(filters=[Filter(column="col1", op="=", value=1)])
+
+            with patch("data_agent.core.executor._digest", return_value="test_digest"), patch(
+                "data_agent.core.evidence.run_rules", return_value={}
+            ):
+                # First execution
+                answer1 = run(lf, plan, cache_manager)
+                assert answer1.evidence["cache"]["hit"] is False
+
+                # Second execution - should have cache metadata
+                answer2 = run(lf, plan, cache_manager)
+                assert answer2.evidence["cache"]["hit"] is True
+
+                # Check that cache metadata is present
+                cache_info = answer2.evidence["cache"]
+                assert "fingerprint" in cache_info
+                assert "ttl_hours" in cache_info
+                assert "cached_at" in cache_info

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,9 +54,10 @@ def test_load_command_success():
 
 def test_ask_command():
     """Test ask command."""
-    result = runner.invoke(app, ["ask", "What is the total flow for Texas?"])
+    # Use a query that matches a deterministic pattern to avoid processing full dataset
+    result = runner.invoke(app, ["ask", "total receipts for ANR"])
     assert result.exit_code == 0
-    assert "Question: What is the total flow for Texas?" in result.stdout
+    assert "Question: total receipts for ANR" in result.stdout
     assert "Using planner: deterministic" in result.stdout
     assert "Answer:" in result.stdout
     assert "Evidence Card:" in result.stdout
@@ -75,7 +76,10 @@ def test_ask_command_with_planner():
 
 def test_ask_command_with_export():
     """Test ask command with export option."""
-    result = runner.invoke(app, ["ask", "test question", "--export", "output.json"])
+    # Use a query that matches a deterministic pattern to avoid processing full dataset
+    result = runner.invoke(
+        app, ["ask", "sum of deliveries for ANR on 2022-01-01", "--export", "output.json"]
+    )
     assert result.exit_code == 0
     assert "Results exported to: output.json" in result.stdout
 
@@ -157,7 +161,8 @@ def test_cache_command_stats():
     """Test cache stats command."""
     result = runner.invoke(app, ["cache", "--stats"])
     assert result.exit_code == 0
-    assert "Cache statistics (placeholder)" in result.stdout
+    assert "Cache Statistics:" in result.stdout
+    assert "Total files:" in result.stdout
 
 
 def test_cache_command_conflicting_options():

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -376,7 +376,7 @@ class TestLLMPlanner:
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
-        
+
         # Mock tool_calls structure
         mock_tool_call = MagicMock()
         mock_tool_call.function.arguments = json.dumps(


### PR DESCRIPTION
**Steps**

* Compute fingerprint from canonical Plan JSON + dataset digest.
* Store result DataFrame + evidence JSON to `./.cache/results/{hash}.parquet/json`.
* Evidence shows cache status & TTL.

**Acceptance**

* Repeated query returns `cache.hit=True` and faster elapsed time in test.