### PR TITLE
added analytics metrics

### DIFF
--- a/src/data_agent/core/metrics.py
+++ b/src/data_agent/core/metrics.py
@@ -1,0 +1,170 @@
+"""Analytics metrics functions for gas pipeline data."""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def ramp_risk(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """Calculate ramp risk index for pipeline/location entities.
+
+    Ramp risk = p95(|Δ day|) / median(flow)
+
+    Args:
+        lf: Lazy frame with columns: pipeline_name, loc_name, eff_gas_day, scheduled_quantity
+
+    Returns:
+        Lazy frame with columns: pipeline_name, loc_name, ramp_risk, n_days,
+        p95_abs_delta, median_flow
+    """
+    return (
+        lf.sort(["pipeline_name", "loc_name", "eff_gas_day"])
+        .with_columns(
+            [
+                # Calculate daily delta (absolute change from previous day)
+                pl.col("scheduled_quantity")
+                .diff()
+                .abs()
+                .over(["pipeline_name", "loc_name"])
+                .alias("abs_delta")
+            ]
+        )
+        .group_by(["pipeline_name", "loc_name"])
+        .agg(
+            [
+                pl.len().alias("n_days"),
+                pl.col("abs_delta").quantile(0.95).alias("p95_abs_delta"),
+                pl.col("scheduled_quantity").median().alias("median_flow"),
+            ]
+        )
+        .with_columns(
+            [
+                # Calculate ramp risk, handle division by zero and null deltas
+                pl.when(pl.col("p95_abs_delta").is_null())
+                .then(0.0)  # If no deltas (single day), ramp risk is 0
+                .otherwise(
+                    pl.col("p95_abs_delta")
+                    / pl.max_horizontal([pl.col("median_flow"), pl.lit(1.0)])
+                )
+                .alias("ramp_risk")
+            ]
+        )
+        .select(
+            ["pipeline_name", "loc_name", "ramp_risk", "n_days", "p95_abs_delta", "median_flow"]
+        )
+    )
+
+
+def reversal_freq(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """Calculate reversal frequency for pipeline connections.
+
+    Reversal frequency = fraction of days with sign change in net flow
+
+    Args:
+        lf: Lazy frame with columns: pipeline_name, connecting_entity, eff_gas_day,
+            rec_del_sign, scheduled_quantity
+
+    Returns:
+        Lazy frame with columns: pipeline_name, connecting_entity, reversal_freq,
+        n_days, n_reversals, net_flow_std
+    """
+    return (
+        lf.with_columns(
+            [
+                # Calculate net flow (positive for receipts, negative for deliveries)
+                (pl.col("rec_del_sign") * pl.col("scheduled_quantity")).alias("net_flow")
+            ]
+        )
+        .group_by(["pipeline_name", "connecting_entity", "eff_gas_day"])
+        .agg([pl.col("net_flow").sum().alias("daily_net_flow")])
+        .sort(["pipeline_name", "connecting_entity", "eff_gas_day"])
+        .with_columns(
+            [
+                # Detect sign changes (reversals)
+                (pl.col("daily_net_flow").sign() != pl.col("daily_net_flow").sign().shift(1))
+                .over(["pipeline_name", "connecting_entity"])
+                .alias("is_reversal")
+            ]
+        )
+        .group_by(["pipeline_name", "connecting_entity"])
+        .agg(
+            [
+                pl.len().alias("n_days"),
+                pl.col("is_reversal").sum().alias("n_reversals"),
+                pl.col("daily_net_flow").std().alias("net_flow_std"),
+            ]
+        )
+        .with_columns(
+            [
+                # Calculate reversal frequency
+                (pl.col("n_reversals") / pl.max_horizontal([pl.col("n_days"), pl.lit(1)])).alias(
+                    "reversal_freq"
+                )
+            ]
+        )
+        .select(
+            [
+                "pipeline_name",
+                "connecting_entity",
+                "reversal_freq",
+                "n_days",
+                "n_reversals",
+                "net_flow_std",
+            ]
+        )
+    )
+
+
+def imbalance_pct(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """Calculate daily imbalance percentage per pipeline.
+
+    Imbalance% = |receipts - deliveries| / max(receipts, 1) * 100
+
+    Args:
+        lf: Lazy frame with columns: pipeline_name, eff_gas_day, rec_del_sign, scheduled_quantity
+
+    Returns:
+        Lazy frame with columns: pipeline_name, eff_gas_day, imbalance_pct,
+        total_receipts, total_deliveries, net_flow
+    """
+    return (
+        lf.group_by(["pipeline_name", "eff_gas_day"])
+        .agg(
+            [
+                # Sum receipts (positive rec_del_sign)
+                pl.when(pl.col("rec_del_sign") > 0)
+                .then(pl.col("scheduled_quantity"))
+                .otherwise(0)
+                .sum()
+                .alias("total_receipts"),
+                # Sum deliveries (negative rec_del_sign)
+                pl.when(pl.col("rec_del_sign") < 0)
+                .then(pl.col("scheduled_quantity"))
+                .otherwise(0)
+                .sum()
+                .alias("total_deliveries"),
+            ]
+        )
+        .with_columns(
+            [
+                # Calculate net flow and imbalance percentage
+                (pl.col("total_receipts") - pl.col("total_deliveries")).alias("net_flow"),
+                (
+                    (pl.col("total_receipts") - pl.col("total_deliveries")).abs()
+                    / pl.max_horizontal([pl.col("total_receipts"), pl.lit(1.0)])
+                    * 100.0
+                ).alias("imbalance_pct"),
+            ]
+        )
+        .select(
+            [
+                "pipeline_name",
+                "eff_gas_day",
+                "imbalance_pct",
+                "total_receipts",
+                "total_deliveries",
+                "net_flow",
+            ]
+        )
+        .sort(["pipeline_name", "eff_gas_day"])
+    )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,215 @@
+"""Tests for metrics functions."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from data_agent.core.metrics import imbalance_pct, ramp_risk, reversal_freq
+
+
+class TestRampRisk:
+    """Test ramp_risk function."""
+
+    def test_ramp_risk_basic(self):
+        """Test basic ramp risk calculation."""
+        # Create toy data with known deltas
+        df = pl.DataFrame(
+            {
+                "pipeline_name": ["A", "A", "A", "A"],
+                "loc_name": ["L1", "L1", "L1", "L1"],
+                "eff_gas_day": ["2022-01-01", "2022-01-02", "2022-01-03", "2022-01-04"],
+                "scheduled_quantity": [100.0, 110.0, 90.0, 100.0],  # deltas: 10, 20, 10
+            }
+        ).with_columns(pl.col("eff_gas_day").str.to_date())
+
+        result = ramp_risk(df.lazy()).collect()
+
+        assert len(result) == 1
+        assert result["pipeline_name"][0] == "A"
+        assert result["loc_name"][0] == "L1"
+        assert result["n_days"][0] == 4
+
+        # p95 of [10, 20, 10] = 20, median of [100, 110, 90, 100] = 100
+        # ramp_risk = 20 / 100 = 0.2
+        assert result["p95_abs_delta"][0] == 20.0
+        assert result["median_flow"][0] == 100.0
+        assert result["ramp_risk"][0] == pytest.approx(0.2)
+
+    def test_ramp_risk_multiple_entities(self):
+        """Test ramp risk with multiple pipeline/location combinations."""
+        df = pl.DataFrame(
+            {
+                "pipeline_name": ["A", "A", "B", "B"],
+                "loc_name": ["L1", "L1", "L2", "L2"],
+                "eff_gas_day": ["2022-01-01", "2022-01-02", "2022-01-01", "2022-01-02"],
+                "scheduled_quantity": [100.0, 120.0, 50.0, 55.0],
+            }
+        ).with_columns(pl.col("eff_gas_day").str.to_date())
+
+        result = ramp_risk(df.lazy()).collect().sort(["pipeline_name", "loc_name"])
+
+        assert len(result) == 2
+        assert result["pipeline_name"].to_list() == ["A", "B"]
+        assert result["loc_name"].to_list() == ["L1", "L2"]
+
+    def test_ramp_risk_zero_median(self):
+        """Test ramp risk handles zero median flow."""
+        df = pl.DataFrame(
+            {
+                "pipeline_name": ["A", "A", "A"],
+                "loc_name": ["L1", "L1", "L1"],
+                "eff_gas_day": ["2022-01-01", "2022-01-02", "2022-01-03"],
+                "scheduled_quantity": [0.0, 0.0, 10.0],  # median = 0.0
+            }
+        ).with_columns(pl.col("eff_gas_day").str.to_date())
+
+        result = ramp_risk(df.lazy()).collect()
+
+        # Should use max(median_flow, 1.0) = 1.0 as denominator
+        # p95 of deltas [0, 10] = 10, so ramp_risk = 10/1 = 10
+        assert result["ramp_risk"][0] == 10.0
+
+
+class TestReversalFreq:
+    """Test reversal_freq function."""
+
+    def test_reversal_freq_basic(self):
+        """Test basic reversal frequency calculation."""
+        df = pl.DataFrame(
+            {
+                "pipeline_name": ["A", "A", "A", "A"],
+                "connecting_entity": ["E1", "E1", "E1", "E1"],
+                "eff_gas_day": ["2022-01-01", "2022-01-02", "2022-01-03", "2022-01-04"],
+                "rec_del_sign": [1, 1, -1, -1],  # Receipt, Receipt, Delivery, Delivery
+                "scheduled_quantity": [100.0, 50.0, 75.0, 25.0],
+            }
+        ).with_columns(pl.col("eff_gas_day").str.to_date())
+
+        result = reversal_freq(df.lazy()).collect()
+
+        assert len(result) == 1
+        assert result["pipeline_name"][0] == "A"
+        assert result["connecting_entity"][0] == "E1"
+        assert result["n_days"][0] == 4
+
+        # Net flows: [100, 50, -75, -25], signs: [+, +, -, -]
+        # Reversals: day 3 (+ to -)
+        assert result["n_reversals"][0] == 1
+        assert result["reversal_freq"][0] == pytest.approx(0.25)
+
+    def test_reversal_freq_no_reversals(self):
+        """Test reversal frequency with no sign changes."""
+        df = pl.DataFrame(
+            {
+                "pipeline_name": ["A", "A", "A"],
+                "connecting_entity": ["E1", "E1", "E1"],
+                "eff_gas_day": ["2022-01-01", "2022-01-02", "2022-01-03"],
+                "rec_del_sign": [1, 1, 1],
+                "scheduled_quantity": [100.0, 50.0, 75.0],
+            }
+        ).with_columns(pl.col("eff_gas_day").str.to_date())
+
+        result = reversal_freq(df.lazy()).collect()
+
+        assert result["n_reversals"][0] == 0
+        assert result["reversal_freq"][0] == 0.0
+
+    def test_reversal_freq_multiple_entities(self):
+        """Test reversal frequency with multiple connections."""
+        df = pl.DataFrame(
+            {
+                "pipeline_name": ["A", "A", "B", "B"],
+                "connecting_entity": ["E1", "E1", "E2", "E2"],
+                "eff_gas_day": ["2022-01-01", "2022-01-02", "2022-01-01", "2022-01-02"],
+                "rec_del_sign": [1, -1, 1, 1],
+                "scheduled_quantity": [100.0, 50.0, 75.0, 25.0],
+            }
+        ).with_columns(pl.col("eff_gas_day").str.to_date())
+
+        result = reversal_freq(df.lazy()).collect().sort(["pipeline_name", "connecting_entity"])
+
+        assert len(result) == 2
+        assert result["n_reversals"].to_list() == [1, 0]  # A-E1 has reversal, B-E2 doesn't
+
+
+class TestImbalancePct:
+    """Test imbalance_pct function."""
+
+    def test_imbalance_pct_basic(self):
+        """Test basic imbalance percentage calculation."""
+        df = pl.DataFrame(
+            {
+                "pipeline_name": ["A", "A", "A"],
+                "eff_gas_day": ["2022-01-01", "2022-01-01", "2022-01-01"],
+                "rec_del_sign": [1, 1, -1],  # Two receipts, one delivery
+                "scheduled_quantity": [100.0, 50.0, 75.0],
+            }
+        ).with_columns(pl.col("eff_gas_day").str.to_date())
+
+        result = imbalance_pct(df.lazy()).collect()
+
+        assert len(result) == 1
+        assert result["pipeline_name"][0] == "A"
+        assert result["total_receipts"][0] == 150.0
+        assert result["total_deliveries"][0] == 75.0
+        assert result["net_flow"][0] == 75.0
+
+        # Imbalance = |150 - 75| / 150 * 100 = 50%
+        assert result["imbalance_pct"][0] == pytest.approx(50.0)
+
+    def test_imbalance_pct_multiple_days(self):
+        """Test imbalance percentage across multiple days."""
+        df = pl.DataFrame(
+            {
+                "pipeline_name": ["A", "A", "A", "A"],
+                "eff_gas_day": ["2022-01-01", "2022-01-01", "2022-01-02", "2022-01-02"],
+                "rec_del_sign": [1, -1, 1, -1],
+                "scheduled_quantity": [100.0, 100.0, 50.0, 60.0],
+            }
+        ).with_columns(pl.col("eff_gas_day").str.to_date())
+
+        result = imbalance_pct(df.lazy()).collect().sort("eff_gas_day")
+
+        assert len(result) == 2
+
+        # Day 1: receipts=100, deliveries=100, imbalance=0%
+        assert result["imbalance_pct"][0] == 0.0
+
+        # Day 2: receipts=50, deliveries=60, imbalance=|50-60|/50*100=20%
+        assert result["imbalance_pct"][1] == pytest.approx(20.0)
+
+    def test_imbalance_pct_zero_receipts(self):
+        """Test imbalance percentage handles zero receipts."""
+        df = pl.DataFrame(
+            {
+                "pipeline_name": ["A", "A"],
+                "eff_gas_day": ["2022-01-01", "2022-01-01"],
+                "rec_del_sign": [-1, -1],
+                "scheduled_quantity": [50.0, 25.0],
+            }
+        ).with_columns(pl.col("eff_gas_day").str.to_date())
+
+        result = imbalance_pct(df.lazy()).collect()
+
+        # Should use max(receipts, 1.0) = 1.0 as denominator
+        assert result["total_receipts"][0] == 0.0
+        assert result["imbalance_pct"][0] == pytest.approx(7500.0)  # 75/1*100
+
+    def test_imbalance_pct_multiple_pipelines(self):
+        """Test imbalance percentage with multiple pipelines."""
+        df = pl.DataFrame(
+            {
+                "pipeline_name": ["A", "A", "B", "B"],
+                "eff_gas_day": ["2022-01-01", "2022-01-01", "2022-01-01", "2022-01-01"],
+                "rec_del_sign": [1, -1, 1, -1],
+                "scheduled_quantity": [100.0, 50.0, 200.0, 200.0],
+            }
+        ).with_columns(pl.col("eff_gas_day").str.to_date())
+
+        result = imbalance_pct(df.lazy()).collect().sort("pipeline_name")
+
+        assert len(result) == 2
+        assert result["pipeline_name"].to_list() == ["A", "B"]
+        assert result["imbalance_pct"][0] == pytest.approx(50.0)  # A: |100-50|/100*100
+        assert result["imbalance_pct"][1] == pytest.approx(0.0)  # B: |200-200|/200*100

--- a/tests/test_metrics_integration.py
+++ b/tests/test_metrics_integration.py
@@ -1,0 +1,243 @@
+"""Integration tests for metrics functions using golden.parquet."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from data_agent.core.metrics import imbalance_pct, ramp_risk, reversal_freq
+from data_agent.core.ops import apply_plan
+from data_agent.core.plan_schema import Filter, Plan
+
+
+class TestMetricsIntegration:
+    """Integration tests using golden.parquet dataset."""
+
+    @pytest.fixture
+    def golden_df(self):
+        """Load the golden dataset."""
+        return pl.scan_parquet("examples/golden.parquet")
+
+    def test_ramp_risk_integration(self, golden_df):
+        """Test ramp_risk on golden dataset."""
+        # Apply some filters to get a manageable subset
+        plan = Plan(
+            filters=[
+                Filter(column="pipeline_name", op="=", value="ANR Pipeline Company"),
+                Filter(column="eff_gas_day", op="between", value=["2022-01-01", "2022-03-31"]),
+            ]
+        )
+
+        filtered_lf = apply_plan(golden_df, plan)
+        result = ramp_risk(filtered_lf).collect()
+
+        # Verify structure
+        assert "pipeline_name" in result.columns
+        assert "loc_name" in result.columns
+        assert "ramp_risk" in result.columns
+        assert "n_days" in result.columns
+        assert "p95_abs_delta" in result.columns
+        assert "median_flow" in result.columns
+
+        # Verify data types
+        assert result["ramp_risk"].dtype == pl.Float64
+        assert result["n_days"].dtype == pl.UInt32
+
+        # Verify non-negative values
+        assert all(result["ramp_risk"] >= 0)
+        assert all(result["n_days"] > 0)
+
+        # Should have results for multiple locations
+        assert len(result) > 0
+        print(f"Ramp risk results: {len(result)} locations")
+        print(result.head())
+
+    def test_reversal_freq_integration(self, golden_df):
+        """Test reversal_freq on golden dataset."""
+        # Apply filters to get subset with potential reversals
+        plan = Plan(
+            filters=[
+                Filter(column="pipeline_name", op="=", value="ANR Pipeline Company"),
+                Filter(column="eff_gas_day", op="between", value=["2022-01-01", "2022-03-31"]),
+            ]
+        )
+
+        filtered_lf = apply_plan(golden_df, plan)
+        result = reversal_freq(filtered_lf).collect()
+
+        # Verify structure
+        assert "pipeline_name" in result.columns
+        assert "connecting_entity" in result.columns
+        assert "reversal_freq" in result.columns
+        assert "n_days" in result.columns
+        assert "n_reversals" in result.columns
+        assert "net_flow_std" in result.columns
+
+        # Verify data types
+        assert result["reversal_freq"].dtype == pl.Float64
+        assert result["n_days"].dtype == pl.UInt32
+        assert result["n_reversals"].dtype == pl.UInt32
+
+        # Verify ranges
+        assert all(result["reversal_freq"] >= 0)
+        assert all(result["reversal_freq"] <= 1)
+        assert all(result["n_days"] > 0)
+        assert all(result["n_reversals"] >= 0)
+
+        # Should have results
+        assert len(result) > 0
+        print(f"Reversal frequency results: {len(result)} connections")
+        print(result.head())
+
+    def test_imbalance_pct_integration(self, golden_df):
+        """Test imbalance_pct on golden dataset."""
+        # Apply filters to get subset
+        plan = Plan(
+            filters=[
+                Filter(column="pipeline_name", op="=", value="ANR Pipeline Company"),
+                Filter(column="eff_gas_day", op="between", value=["2022-01-01", "2022-01-31"]),
+            ]
+        )
+
+        filtered_lf = apply_plan(golden_df, plan)
+        result = imbalance_pct(filtered_lf).collect()
+
+        # Verify structure
+        assert "pipeline_name" in result.columns
+        assert "eff_gas_day" in result.columns
+        assert "imbalance_pct" in result.columns
+        assert "total_receipts" in result.columns
+        assert "total_deliveries" in result.columns
+        assert "net_flow" in result.columns
+
+        # Verify data types
+        assert result["imbalance_pct"].dtype == pl.Float64
+        assert result["total_receipts"].dtype == pl.Float64
+        assert result["total_deliveries"].dtype == pl.Float64
+
+        # Verify non-negative values for quantities
+        assert all(result["total_receipts"] >= 0)
+        assert all(result["total_deliveries"] >= 0)
+        assert all(result["imbalance_pct"] >= 0)
+
+        # Should have daily results
+        assert len(result) > 0
+        print(f"Imbalance results: {len(result)} days")
+        print(result.head())
+
+    def test_metric_compute_via_ops(self, golden_df):
+        """Test metrics via the ops.apply_plan interface."""
+        # Test ramp_risk via metric_compute operation
+        plan = Plan(
+            filters=[
+                Filter(column="pipeline_name", op="=", value="ANR Pipeline Company"),
+                Filter(column="eff_gas_day", op="between", value=["2022-01-01", "2022-03-31"]),
+            ],
+            op="metric_compute",
+            op_args={"name": "ramp_risk"},
+        )
+
+        result = apply_plan(golden_df, plan).collect()
+
+        # Should have ramp_risk results
+        assert "ramp_risk" in result.columns
+        assert len(result) > 0
+
+        # Test reversal_freq via metric_compute operation
+        plan = Plan(
+            filters=[
+                Filter(column="pipeline_name", op="=", value="ANR Pipeline Company"),
+                Filter(column="eff_gas_day", op="between", value=["2022-01-01", "2022-03-31"]),
+            ],
+            op="metric_compute",
+            op_args={"name": "reversal_freq"},
+        )
+
+        result = apply_plan(golden_df, plan).collect()
+
+        # Should have reversal_freq results
+        assert "reversal_freq" in result.columns
+        assert len(result) > 0
+
+        # Test imbalance_pct via metric_compute operation
+        plan = Plan(
+            filters=[
+                Filter(column="pipeline_name", op="=", value="ANR Pipeline Company"),
+                Filter(column="eff_gas_day", op="between", value=["2022-01-01", "2022-01-31"]),
+            ],
+            op="metric_compute",
+            op_args={"name": "imbalance_pct"},
+        )
+
+        result = apply_plan(golden_df, plan).collect()
+
+        # Should have imbalance_pct results
+        assert "imbalance_pct" in result.columns
+        assert len(result) > 0
+
+    def test_unknown_metric_error(self, golden_df):
+        """Test that unknown metric names raise errors."""
+        plan = Plan(op="metric_compute", op_args={"name": "unknown_metric"})
+
+        with pytest.raises(ValueError, match="Unknown metric: unknown_metric"):
+            apply_plan(golden_df, plan).collect()
+
+    def test_metrics_respect_filters(self, golden_df):
+        """Test that metrics respect applied filters."""
+        # Test with no filters
+        plan_all = Plan(op="metric_compute", op_args={"name": "ramp_risk"})
+        result_all = apply_plan(golden_df, plan_all).collect()
+
+        # Test with filters
+        plan_filtered = Plan(
+            filters=[Filter(column="pipeline_name", op="=", value="ANR Pipeline Company")],
+            op="metric_compute",
+            op_args={"name": "ramp_risk"},
+        )
+        result_filtered = apply_plan(golden_df, plan_filtered).collect()
+
+        # Filtered result should be smaller or equal
+        assert len(result_filtered) <= len(result_all)
+
+        # All results should be for ANR Pipeline Company only
+        unique_pipelines = result_filtered["pipeline_name"].unique().to_list()
+        assert unique_pipelines == ["ANR Pipeline Company"]
+
+    def test_metrics_output_tidy_tables(self, golden_df):
+        """Test that metrics output well-structured tidy tables."""
+        plan = Plan(
+            filters=[
+                Filter(
+                    column="pipeline_name",
+                    op="in",
+                    value=["ANR Pipeline Company", "Columbia Gulf Transmission Company"],
+                )
+            ],
+            op="metric_compute",
+            op_args={"name": "imbalance_pct"},
+        )
+
+        result = apply_plan(golden_df, plan).collect()
+
+        # Should be tidy: one row per pipeline-day combination
+        assert len(result) > 0
+
+        # Check for duplicates (should be none in tidy format)
+        grouped = result.group_by(["pipeline_name", "eff_gas_day"]).len()
+        assert all(grouped["len"] == 1)  # Each combination should appear exactly once
+
+        # Columns should be well-named and typed
+        expected_cols = [
+            "pipeline_name",
+            "eff_gas_day",
+            "imbalance_pct",
+            "total_receipts",
+            "total_deliveries",
+            "net_flow",
+        ]
+        for col in expected_cols:
+            assert col in result.columns
+
+        # Should be sorted by pipeline and date
+        sorted_result = result.sort(["pipeline_name", "eff_gas_day"])
+        assert result.equals(sorted_result)


### PR DESCRIPTION
**Steps**

* Implement `ramp_risk`, `reversal_freq`, `imbalance_pct` functions that can be called via `op="metric_compute"` with `op_args.name`.
* Respect current filters; output tidy tables with well-named columns.

**Acceptance**

* Unit tests on toy series; integration on golden with snapshot tables.